### PR TITLE
Fix for Recorder

### DIFF
--- a/src/Wolfie2D/Playback/BasicReplayer.ts
+++ b/src/Wolfie2D/Playback/BasicReplayer.ts
@@ -89,6 +89,7 @@ export default class BasicReplayer implements Replayer<BasicRecording, BasicLogI
             InputHandlers.MOUSE_MOVE, InputHandlers.KEY_DOWN, InputHandlers.KEY_UP, 
             InputHandlers.ON_BLUR, InputHandlers.ON_WHEEL
         ]});
+        this.emitter.fireEvent(GameEventType.CANVAS_BLUR)
     }
     /**
      * @see Replayer.destroy()


### PR DESCRIPTION
If a recording records a keypress down, but not the respective keypress up, the input hander will believe that the keypress is still being pressed after a replay. This resets the input handler after the replay.